### PR TITLE
fix(omnigraph): stop apply/import failures from crash-looping the pod

### DIFF
--- a/examples/omnigraph/main.tf
+++ b/examples/omnigraph/main.tf
@@ -133,8 +133,22 @@ module "omnigraph" {
   }
 
   # ── InitContainers ───────────────────────────────────────────────
+  #
+  # IMPORTANT: `cluster import` and `cluster apply` are NOT init containers.
+  #
+  # Init containers must exit 0 or Kubernetes restarts the whole pod and never
+  # starts the server. `cluster apply` legitimately exits non-zero on routine
+  # events (a schema change while agent/review branches are open, or a
+  # migration that needs a data backfill), and `cluster import` exits non-zero
+  # once state exists ("already exists"). Putting either on the boot path turned
+  # those routine failures into a CrashLoopBackOff where the server never came
+  # up. Convergence is now owned by the `converge` sidecar below, which runs
+  # loudly but never blocks serving. The server boots from the applied state on
+  # S3 (OMNIGRAPH_CLUSTER), so it needs no local config to serve.
   init_containers = [
-    # 1. Git sync at startup (alpine/git has git)
+    # Seed /config from git so the sidecars have the cluster config on first
+    # boot (before the git poller's first fetch). Pure file fetch — safe as an
+    # init container because a git clone failure genuinely should block start.
     {
       name  = "git-sync"
       image = "alpine/git:latest"
@@ -163,72 +177,22 @@ module "omnigraph" {
         }
       ]
     },
-
-    # 2. Import schema (omnigraph image has omnigraph CLI)
-    {
-      name  = "import-schema"
-      image = var.image
-
-      env = [
-        { name = "AWS_ACCESS_KEY_ID", value = var.rustfs_storage_access },
-        { name = "AWS_SECRET_ACCESS_KEY", value = var.rustfs_storage_secret },
-        { name = "AWS_REGION", value = var.aws_region },
-        { name = "AWS_ENDPOINT_URL", value = "http://${module.rustfs.name}:${module.rustfs.ports[0].port}" },
-        { name = "AWS_S3_FORCE_PATH_STYLE", value = "true" },
-        { name = "AWS_ALLOW_HTTP", value = "true" },
-        { name = "AWS_EC2_METADATA_DISABLED", value = "true" },
-      ]
-
-      command = [
-        "/bin/sh", "-c", <<-EOT
-          echo "Importing schema..."
-          omnigraph cluster import --config /config --yes
-          echo "Schema imported"
-        EOT
-      ]
-
-      volume_mounts = [
-        {
-          name       = "config-volume"
-          mount_path = "/config"
-        }
-      ]
-    },
-
-    # 3. Apply graph (omnigraph image has omnigraph CLI)
-    {
-      name  = "apply-graph"
-      image = var.image
-
-      env = [
-        { name = "AWS_ACCESS_KEY_ID", value = var.rustfs_storage_access },
-        { name = "AWS_SECRET_ACCESS_KEY", value = var.rustfs_storage_secret },
-        { name = "AWS_REGION", value = var.aws_region },
-        { name = "AWS_ENDPOINT_URL", value = "http://${module.rustfs.name}:${module.rustfs.ports[0].port}" },
-        { name = "AWS_S3_FORCE_PATH_STYLE", value = "true" },
-        { name = "AWS_ALLOW_HTTP", value = "true" },
-        { name = "AWS_EC2_METADATA_DISABLED", value = "true" },
-      ]
-
-      command = [
-        "/bin/sh", "-c", <<-EOT
-          echo "Applying graph..."
-          omnigraph cluster apply --config /config --yes
-          echo "Graph applied"
-        EOT
-      ]
-
-      volume_mounts = [
-        {
-          name       = "config-volume"
-          mount_path = "/config"
-        }
-      ]
-    },
   ]
 
-  # ── Sidecar: Git poller ─────────────────────────────────────────
+  # ── Sidecars ─────────────────────────────────────────────────────
+  #
+  # Two-stage convergence, decoupled from the server's boot:
+  #   * git-poller (alpine/git) keeps /config matching the repo. It NO LONGER
+  #     restarts the server — its only job is git -> /config.
+  #   * converge   (omnigraph)  owns bootstrap + `cluster apply`, runs loudly,
+  #     and restarts the server ONLY after a successful apply. A failed apply is
+  #     logged and left visible; the server keeps serving the last-good state.
+  #
+  # This is what keeps a convergence failure from ever taking serving down,
+  # and it pairs with the engine fix (#284) that lets the server boot and
+  # quarantine a single partially-applied graph instead of refusing to start.
   sidecars = [
+    # 1. Keep /config in sync with git. File fetch only; no process control.
     {
       name  = "git-poller"
       image = "alpine/git:latest"
@@ -240,19 +204,6 @@ module "omnigraph" {
           GIT_BRANCH="${var.config_git_branch}"
           GIT_TOKEN="${var.git_auth_token}"
 
-          # Function to find the main omnigraph process PID
-          find_omnigraph_pid() {
-            for pid_dir in /proc/[0-9]*/; do
-              pid=$(basename "$pid_dir")
-              if [ -f "/proc/$pid/cmdline" ] && grep -q "omnigraph-server" "/proc/$pid/cmdline" 2>/dev/null; then
-                echo "$pid"
-                return 0
-              fi
-            done
-            return 1
-          }
-
-          # Initial clone for the sidecar
           AUTH_REPO="$GIT_REPO"
           if [ -n "$GIT_TOKEN" ]; then
             AUTH_REPO="https://$GIT_TOKEN@github.com/$(echo $GIT_REPO | sed 's|.*github.com/||')"
@@ -264,31 +215,107 @@ module "omnigraph" {
           echo "Starting git poller (interval: $POLL_INTERVAL seconds)..."
           while true; do
             sleep "$POLL_INTERVAL"
-
             cd /config/repo
             git fetch origin "$GIT_BRANCH" 2>/dev/null
             NEW_HEAD=$(git rev-parse --verify origin/"$GIT_BRANCH")
             OLD_HEAD=$(git rev-parse HEAD)
-
             if [ "$NEW_HEAD" != "$OLD_HEAD" ]; then
               echo "Config change detected! $OLD_HEAD -> $NEW_HEAD"
               git pull origin "$GIT_BRANCH" --ff-only 2>/dev/null || git pull origin "$GIT_BRANCH"
-
-              # Sync files back to shared volume
+              # Publish into the shared volume; the converge sidecar notices and applies.
               cp -r /config/repo/* /config/
-
-               # Since share_process_namespace=true, we can kill directly
-               OMNIGRAPH_PID=$(find_omnigraph_pid)
-               if [ -n "$OMNIGRAPH_PID" ] && kill -0 "$OMNIGRAPH_PID" 2>/dev/null; then
-                 echo "Sending SIGTERM to omnigraph (PID: $OMNIGRAPH_PID)"
-                 kill -TERM "$OMNIGRAPH_PID"
-                 echo "Omnigraph restarted"
-               else
-                 echo "WARNING: Could not find omnigraph process"
-               fi
             else
               echo "No changes detected"
             fi
+          done
+        EOT
+      ]
+
+      volume_mounts = [
+        {
+          name       = "config-volume"
+          mount_path = "/config"
+        }
+      ]
+    },
+
+    # 2. Bootstrap once, then converge on every /config change. LOUD, but never
+    #    fatal to serving. Restarts the server (SIGTERM, share_process_namespace)
+    #    only after a successful apply so it picks up the new applied state.
+    {
+      name  = "converge"
+      image = var.image
+
+      env = [
+        { name = "AWS_ACCESS_KEY_ID", value = var.rustfs_storage_access },
+        { name = "AWS_SECRET_ACCESS_KEY", value = var.rustfs_storage_secret },
+        { name = "AWS_REGION", value = var.aws_region },
+        { name = "AWS_ENDPOINT_URL", value = "http://${module.rustfs.name}:${module.rustfs.ports[0].port}" },
+        { name = "AWS_S3_FORCE_PATH_STYLE", value = "true" },
+        { name = "AWS_ALLOW_HTTP", value = "true" },
+        { name = "AWS_EC2_METADATA_DISABLED", value = "true" },
+        { name = "POLL_INTERVAL", value = tostring(var.config_git_poll_interval) },
+      ]
+
+      command = [
+        "/bin/sh", "-c", <<-EOT
+          set -u
+
+          # Bootstrap the state ledger exactly once. `cluster import` creates it;
+          # on every later pod start it reports "already exists" — that is benign
+          # and expected, so we skip it. ANY OTHER import failure is real and
+          # printed loudly (we do not blanket-swallow with `|| true`).
+          bootstrap() {
+            out=$(omnigraph cluster import --config /config --yes 2>&1)
+            rc=$?
+            if [ $rc -eq 0 ]; then
+              echo "bootstrap: state initialized"
+            elif echo "$out" | grep -q "state_already_exists"; then
+              echo "bootstrap: state already exists (ok)"
+            else
+              echo "BOOTSTRAP IMPORT FAILED (rc=$rc):"; echo "$out"
+            fi
+          }
+
+          # Find the server PID (procps may be absent; scan /proc like the
+          # original poller did).
+          find_server_pid() {
+            for d in /proc/[0-9]*/; do
+              p=$(basename "$d")
+              if [ -f "/proc/$p/cmdline" ] && grep -q "omnigraph-server" "/proc/$p/cmdline" 2>/dev/null; then
+                echo "$p"; return 0
+              fi
+            done
+            return 1
+          }
+
+          config_hash() {
+            find /config -type f -not -path '*/.git/*' -not -path '*/repo/*' \
+              -exec sha256sum {} \; 2>/dev/null | sort | sha256sum
+          }
+
+          bootstrap
+
+          applied=""
+          while true; do
+            h=$(config_hash)
+            if [ "$h" != "$applied" ]; then
+              echo "Converging (cluster apply)..."
+              if omnigraph cluster apply --config /config --yes; then
+                echo "apply: converged"
+                applied="$h"
+                pid=$(find_server_pid) && [ -n "$pid" ] && {
+                  echo "Restarting server (PID $pid) to pick up applied state"
+                  kill -TERM "$pid"
+                }
+              else
+                # LOUD on purpose: a real convergence failure (open branches,
+                # backfill needed, bad schema). Server stays up on last-good
+                # state; we retry on the next config change.
+                echo "APPLY FAILED — server keeps serving last-good state; will retry on next change"
+              fi
+            fi
+            sleep "$${POLL_INTERVAL:-15}"
           done
         EOT
       ]

--- a/examples/omnigraph/variables.tf
+++ b/examples/omnigraph/variables.tf
@@ -14,7 +14,10 @@ variable "is_create_namespace" {
 }
 
 variable "image" {
-  description = "Omnigraph server container image"
+  # Requires omnigraph >= 0.7.1: the resilient-boot behavior this example relies
+  # on (a partially-applied/quarantined graph no longer refuses server boot)
+  # landed in 0.7.1. Pin a tag >= 0.7.1 in production rather than `:latest`.
+  description = "Omnigraph server container image (>= 0.7.1)"
   default     = "registry.rebelsoft.com/omnigraph:latest"
 }
 


### PR DESCRIPTION
## Problem

The omnigraph example runs `cluster import` and `cluster apply` as **init containers**. Kubernetes requires an init container to exit `0` or it restarts the whole pod and never starts the app container. But both commands exit non-zero on **routine** events:

- **`cluster apply`** legitimately rejects a schema change while agent/review branches are open, or a migration that needs a data backfill. It exits 1.
- **`cluster import`** is a one-time bootstrap; once state exists it reports `state_already_exists` and exits 1. Since state lives on S3 and persists, **every restart after the first** fails here.

The result: a normal deploy (or any pod restart — node reboot, OOM, eviction) turns into a `CrashLoopBackOff` in which **the server never boots at all**. Convergence (a data-plane concern) was wired onto the server's boot path, so a convergence failure took serving down.

I reproduced it locally with the real binaries: the init sequence `import && apply && server` fails on every restart, so the server never starts.

## The fix has two parts

### Part 1 — omnigraph ≥ 0.7.1 (engine; already released)

Before 0.7.1, a failed/partial `apply` could leave a recovery sidecar that made the **server itself** refuse to boot, and one unhealthy graph took down the whole server. 0.7.1 fixes that: a rejected apply leaves no recovery sidecar, and the server boots and **quarantines** a single partially-applied/unhealthy graph (serving the rest) instead of refusing to start. This is the prerequisite that makes it *safe* to let `apply` fail without taking serving down. (No change needed here beyond using an image `>= 0.7.1`; the `image` variable doc now notes this.)

### Part 2 — this Terraform change (move convergence off the boot path)

- **Init containers:** keep `git-sync` only (a clone failure *should* still block start). Remove `import-schema` and `apply-graph`.
- **`git-poller` sidecar:** now only keeps `/config` synced from git; its server-restart logic moved to the converge sidecar.
- **New `converge` sidecar** (omnigraph image):
  - bootstraps `cluster import` **once**, tolerating only the benign `state_already_exists` — any *other* import failure is printed loudly (no blanket `|| true`);
  - runs `cluster apply` on every `/config` change. A failure is **logged loudly but never blocks serving**; the server keeps serving last-good state and retries on the next change;
  - on a *successful* apply it `SIGTERM`s the server (via the existing `share_process_namespace`) so it picks up the new applied state.
- The server boots from the applied state on S3 (`OMNIGRAPH_CLUSTER`) and no longer depends on a successful convergence.

Net effect: routine convergence failures are **loud and visible** (in the converge sidecar logs) but the service stays up — the opposite of the silent-or-fatal behavior before.

## Verification

- `terraform fmt` parses and `terraform init` succeeds on the example.
- The new `converge` sidecar uses the same field shape as the existing init/sidecar blocks.
- Engine side verified against 0.7.1: a non-main-branch apply correctly exits 1 but leaves **0** recovery sidecars, and `omnigraph-server --cluster` then boots and serves `/healthz` (`{"status":"ok","version":"0.7.1"}`) — where pre-0.7.1 it would have refused on the leftover sidecar.

## Note for maintainers

The `README.md` still describes the old `import`/`apply` init-container flow; I left it untouched to keep this PR focused — happy to update it in this PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)